### PR TITLE
Supporting allure extensions (https://github.com/allure-framework/allure...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/ru/yandex/qatools/allure/report/AllureReportBuilder.java
+++ b/src/main/java/ru/yandex/qatools/allure/report/AllureReportBuilder.java
@@ -2,6 +2,7 @@ package ru.yandex.qatools.allure.report;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.settings.Settings;
 import org.eclipse.aether.artifact.Artifact;
@@ -16,6 +17,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static ru.yandex.qatools.allure.report.AllureArtifacts.getReportDataArtifact;
 import static ru.yandex.qatools.allure.report.internal.RegexJarEntryFilter.filterByRegex;
@@ -119,24 +121,27 @@ public class AllureReportBuilder {
     }
 
     /**
-     * Set extension artifacts in Aether format ({@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}).
-     * Multiple dependencies are allowed with ';' as separator.
+     * Set extension artifacts in Aether format
+     * ({@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}).
      *
-     * @param extensions artifact GAV
+     * @param extensions extension GAVs
      */
-    public void setExtensions(String extensions) {
-        if (StringUtils.isEmpty(extensions)) {
-            // ignore
-            return;
+    public void addExtensions(String... extensions) {
+        for (String extension : extensions) {
+            addExtension(extension);
         }
+    }
 
-        log.info(String.format("Found Allure extensions parameter: '%s'", extensions));
-        String[] artifacts = extensions.split(";");
-        for (String artifactCoordinates : artifacts) {
-            if (!StringUtils.isEmpty(artifactCoordinates)) {
-                this.extensions.add(new DefaultArtifact(artifactCoordinates));
-                log.info(String.format("Allure extension %s added", artifactCoordinates));
-            }
+    /**
+     * Set extension artifact in Aether format
+     * ({@code <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>}).
+     *
+     * @param extension extension GAV
+     */
+    public void addExtension(String extension) {
+        if (!StringUtils.isEmpty(extension)) {
+            this.extensions.add(new DefaultArtifact(extension));
+            log.info(String.format("Allure extension %s added", extension));
         }
     }
 
@@ -164,7 +169,7 @@ public class AllureReportBuilder {
             checkDirectories(inputDirectories);
 
             DefaultArtifact artifact = getReportDataArtifact(version);
-            List<URL> urls = Arrays.asList(aether.resolve(artifact).getAsUrls());
+            Set<URL> urls = Sets.newHashSet(Arrays.asList(aether.resolve(artifact).getAsUrls()));
             for (Artifact extension : extensions) {
                 urls.addAll(Arrays.asList(aether.resolve(extension).getAsUrls()));
             }

--- a/src/test/java/ru/yandex/qatools/allure/report/AllureReportBuilderTest.java
+++ b/src/test/java/ru/yandex/qatools/allure/report/AllureReportBuilderTest.java
@@ -1,5 +1,6 @@
 package ru.yandex.qatools.allure.report;
 
+import org.eclipse.aether.artifact.Artifact;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
@@ -13,8 +14,10 @@ import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
-import static org.junit.Assert.assertThat;
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static ru.yandex.qatools.allure.report.AllureReportBuilderTest.NotEmptyArrayMatcher.notEmpty;
 
 /**
@@ -71,6 +74,29 @@ public class AllureReportBuilderTest {
     public void unpackFaceTest() throws Exception {
         builder.unpackFace();
         assertThat(reportDirectory.list(), notEmpty());
+    }
+
+    @Test
+    public void setExtensionsInvalid() {
+        builder.setExtensions(null);
+        assertEquals(0, builder.getExtensions().size());
+
+        builder.setExtensions("");
+        assertEquals(0, builder.getExtensions().size());
+    }
+
+    @Test
+    public void setSingleExtension() {
+        builder.setExtensions("group:artifact:version");
+        List<Artifact> extensions = builder.getExtensions();
+        assertEquals(1, extensions.size());
+    }
+
+    @Test
+    public void setMultipleExtensions() {
+        builder.setExtensions("group1:artifact1:version1;group2:artifact2:jar:version2;group3:artifact3:jar:jdk5:version3");
+        List<Artifact> extensions = builder.getExtensions();
+        assertEquals(3, extensions.size());
     }
 
     public static class NotEmptyArrayMatcher extends TypeSafeMatcher<String[]> {

--- a/src/test/java/ru/yandex/qatools/allure/report/AllureReportBuilderTest.java
+++ b/src/test/java/ru/yandex/qatools/allure/report/AllureReportBuilderTest.java
@@ -1,6 +1,5 @@
 package ru.yandex.qatools.allure.report;
 
-import org.eclipse.aether.artifact.Artifact;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
@@ -14,9 +13,8 @@ import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 import static ru.yandex.qatools.allure.report.AllureReportBuilderTest.NotEmptyArrayMatcher.notEmpty;
 
@@ -77,26 +75,24 @@ public class AllureReportBuilderTest {
     }
 
     @Test
-    public void setExtensionsInvalid() {
-        builder.setExtensions(null);
-        assertEquals(0, builder.getExtensions().size());
+    public void addExtensionInvalid() {
+        builder.addExtension(null);
+        assertThat(builder.getExtensions(), hasSize(0));
 
-        builder.setExtensions("");
-        assertEquals(0, builder.getExtensions().size());
+        builder.addExtension("");
+        assertThat(builder.getExtensions(), hasSize(0));
     }
 
     @Test
-    public void setSingleExtension() {
-        builder.setExtensions("group:artifact:version");
-        List<Artifact> extensions = builder.getExtensions();
-        assertEquals(1, extensions.size());
+    public void addSingleExtension() {
+        builder.addExtension("group:artifact:version");
+        assertThat(builder.getExtensions(), hasSize(1));
     }
 
     @Test
-    public void setMultipleExtensions() {
-        builder.setExtensions("group1:artifact1:version1;group2:artifact2:jar:version2;group3:artifact3:jar:jdk5:version3");
-        List<Artifact> extensions = builder.getExtensions();
-        assertEquals(3, extensions.size());
+    public void addMultipleExtensions() {
+        builder.addExtensions("group1:artifact1:version1", "group2:artifact2:jar:version2", "group3:artifact3:jar:jdk5:version3");
+        assertThat(builder.getExtensions(), hasSize(3));
     }
 
     public static class NotEmptyArrayMatcher extends TypeSafeMatcher<String[]> {


### PR DESCRIPTION
Issue https://github.com/allure-framework/allure-core/issues/414.

Allure report builder can be configured with extensions (extensions can contain additional SPI implementations, e.g. DataProvider).

Extensions string should be ```<dependency>[;<dependency>]*``` where ```<dependency>``` is string in aether format (```<groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>```).

Later allure maven plugin can be made configurable, as well as Jenkins plugin. For CLI we could configure allure-report-builder via system property or additional argument.